### PR TITLE
Bugfix for problem that $a_cascading_options->options is not countable in each case

### DIFF
--- a/classes/class.ilCascadingSelectInputGUI.php
+++ b/classes/class.ilCascadingSelectInputGUI.php
@@ -13,14 +13,14 @@ class ilCascadingSelectInputGUI extends ilSubEnabledFormPropertyGUI
 {
 	const SEPERATOR = ' → ';
 	
-	private $cascading_values = null;
+	private $cascading_values = [];
 	
 	/**
 	 * @var ilCascadingSelectPlugin 
 	 */
 	private $cascading_plugin;
 	
-	private $column_definition = array();
+	private $column_definition = [];
 	
 	/**
 	 * Constructor

--- a/classes/class.ilCascadingSelectInputGUI.php
+++ b/classes/class.ilCascadingSelectInputGUI.php
@@ -13,7 +13,7 @@ class ilCascadingSelectInputGUI extends ilSubEnabledFormPropertyGUI
 {
 	const SEPERATOR = ' → ';
 	
-	private $cascading_values = [];
+	private $cascading_values = null;
 	
 	/**
 	 * @var ilCascadingSelectPlugin 
@@ -230,7 +230,7 @@ class ilCascadingSelectInputGUI extends ilSubEnabledFormPropertyGUI
 		static $maxdepth = 0;
 		
 		$depth++;
-		if(!count($a_cascading_options->options))
+		if(!is_array($a_cascading_options->options))
 		{
 			$depth--;
 			return $maxdepth;


### PR DESCRIPTION
Whoops\Exception\ErrorException thrown with message "count(): Parameter must be an array or an object that implements Countable"

Stacktrace:
#17 Whoops\Exception\ErrorException in /var/www/ilias/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/classes/class.ilCascadingSelectInputGUI.php:233
